### PR TITLE
chore: Delete LENABI user-journey branch

### DIFF
--- a/download_documents.ts
+++ b/download_documents.ts
@@ -10,7 +10,6 @@ const repos: Repo[] = [
   { name: 'frontend', branch: 'production' },
   { name: 'frontend', branch: 'production' },
   { name: 'frontend', branch: 'meine-mathe-skills' },
-  { name: 'frontend', branch: 'lenabi-user-journey' },
   { name: 'cloudflare-worker', branch: 'staging' },
   { name: 'cloudflare-worker', branch: 'production' },
   { name: 'notification-mail-service', branch: 'main' },


### PR DESCRIPTION
So the `lenabi-user-journey` is completely merged, right?